### PR TITLE
Restrict squeeze dims to prevent squeezing out batch dim

### DIFF
--- a/census/customestimator/trainer/model.py
+++ b/census/customestimator/trainer/model.py
@@ -186,7 +186,7 @@ def generate_model_fn(embedding_size=8,
       # Use the lookup table to convert string labels to ints
       label_indices = table.lookup(labels)
       # Make labels a vector
-      label_indices_vector = tf.squeeze(label_indices)
+      label_indices_vector = tf.squeeze(label_indices, axis=[1])
 
       # global_step is necessary in eval to correctly load the step
       # of the checkpoint we are evaluating


### PR DESCRIPTION
Unless `tf.squeeze` is given an explicit list of axis to squeeze which does not include the batch dimension, it will squeeze batch sizes of 1 into scalars, which will cause `sparse_softmax_cross_entropy_with_logits` to fail with a shape error. This only happens in training if a `allow_final_batches=True` is allowed to trigger, which must require a restriction not based on number of steps but based on epochs. 