### PR TITLE
Workaround for copying h5py to GCS

### DIFF
--- a/census/keras/README.md
+++ b/census/keras/README.md
@@ -92,7 +92,7 @@ gcloud ml-engine local predict --model-dir=$JOB_DIR/export \
 You can train the model on Cloud ML Engine
 
 ```
-gcloud ml-engine jobs submit training $JOB_NAME
+gcloud ml-engine jobs submit training $JOB_NAME \
                                     --stream-logs \
                                     --runtime-version 1.2 \
                                     --job-dir $JOB_DIR \
@@ -100,8 +100,8 @@ gcloud ml-engine jobs submit training $JOB_NAME
                                     --module-name trainer.task \
                                     --region us-central1 \
                                     -- \
-                                    --train-files $TRAIN_FILE \
-                                    --eval-files $EVAL_FILE \
+                                    --train-files $GCS_TRAIN_FILE \
+                                    --eval-files $GCS_EVAL_FILE \
                                     --train-steps $TRAIN_STEPS
 ```
 


### PR DESCRIPTION
For now h5py can't save files directly to GCS paths, this is a hack to work around the problem.