### PR TITLE
Use .whl in requirements.txt

### DIFF
--- a/criteo_tft/requirements.txt
+++ b/criteo_tft/requirements.txt
@@ -1,3 +1,3 @@
 six==1.10.0
 tensorflow==1.3.0
-tensorflow-transform==0.1.10
+https://pypi.python.org/packages/ab/f5/95a12995b8b8d2ffc07b21d33695d241175810ad66116971a206e94d4273/tensorflow_transform-0.1.10-py2-none-any.whl#md5=d3e9e1c061dc112f7e737f5595dc36f8


### PR DESCRIPTION
Because the Dataflow service needs to build the package from source.