### PR TITLE
Adds region tags to select example_serving_input_fn

### DIFF
--- a/census/estimator/trainer/model.py
+++ b/census/estimator/trainer/model.py
@@ -204,7 +204,7 @@ def csv_serving_input_fn():
   features.pop(LABEL_COLUMN)
   return tf.contrib.learn.InputFnOps(features, None, {'csv_row': csv_row})
 
-
+# [START serving-fn-1]
 def example_serving_input_fn():
   """Build the serving inputs."""
   example_bytestring = tf.placeholder(
@@ -224,7 +224,7 @@ def example_serving_input_fn():
       None,  # labels
       {'example_proto': example_bytestring}
   )
-
+# [END serving-fn-1]
 
 def json_serving_input_fn():
   """Build the serving inputs."""


### PR DESCRIPTION
Adding region tags to include example of a serving input fn in the docs.