### PR TITLE
Updated mode='min' for the ModelCheckpoint

### DIFF
--- a/census/keras/trainer/task.py
+++ b/census/keras/trainer/task.py
@@ -108,7 +108,7 @@ def dispatch(train_files,
       monitor='val_loss',
       verbose=1,
       period=checkpoint_epochs,
-      mode='max')
+      mode='min')
 
   # Continuous eval callback
   evaluation = ContinuousEval(eval_frequency,


### PR DESCRIPTION
when `monitor='val_loss'`, we should use `mode='min'` according the Keras documentation https://keras.io/callbacks/#modelcheckpoint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/118)
<!-- Reviewable:end -->
