### PR TITLE
Now needs TF v1.4

### DIFF
--- a/census/keras/README.md
+++ b/census/keras/README.md
@@ -94,7 +94,7 @@ You can train the model on Cloud ML Engine
 ```
 gcloud ml-engine jobs submit training $JOB_NAME \
                                     --stream-logs \
-                                    --runtime-version 1.2 \
+                                    --runtime-version 1.4 \
                                     --job-dir $JOB_DIR \
                                     --package-path trainer \
                                     --module-name trainer.task \


### PR DESCRIPTION
Updated the "Training using Cloud ML Engine" command example to use the version 1.4 of Tensor Flow, now used in this sample.