### PR TITLE
Census Keras input generator fix

### DIFF
--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -23,7 +23,7 @@ import pandas as pd
 from keras import backend as K
 from keras import layers, models
 from keras.utils import np_utils
-from keras.backend import relu, sigmoid
+from keras.backend import relu, softmax
 
 from urlparse import urlparse
 
@@ -69,13 +69,14 @@ def model_fn(input_dim,
     input_dim = units
 
   # Add a dense final layer with sigmoid function
-  model.add(layers.Dense(labels_dim, activation=sigmoid))
+  model.add(layers.Dense(labels_dim, activation=softmax))
   compile_model(model, learning_rate)
   return model
 
 def compile_model(model, learning_rate):
   model.compile(loss='categorical_crossentropy',
                 optimizer=keras.optimizers.SGD(lr=learning_rate),
+		#optimizer='adam',
                 metrics=['accuracy'])
   return model
 

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -126,7 +126,7 @@ def to_numeric_features(features,feature_cols=None):
 
   return features
 
-def generator_input(input_file, chunk_size,batch_size=64):
+def generator_input(input_file, chunk_size, batch_size=64):
   """Generator function to produce features and labels
      needed by keras fit_generator.
   """

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -23,10 +23,7 @@ from keras.utils import np_utils
 from keras.backend import relu, softmax
 
 #Python2/3 compatibility imports
-#   urlparse renamed urllib.parse
 from six.moves.urllib import parse as urlparse
-
-#   range
 from builtins import range
 
 import tensorflow as tf

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -16,8 +16,6 @@
 
 """Implements the Keras Sequential model."""
 
-import itertools
-
 import keras
 import pandas as pd
 from keras import backend as K
@@ -76,7 +74,6 @@ def model_fn(input_dim,
 def compile_model(model, learning_rate):
   model.compile(loss='categorical_crossentropy',
                 optimizer=keras.optimizers.RMSprop(lr=learning_rate),
-                #optimizer='adam',
                 metrics=['accuracy'])
   return model
 

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -58,7 +58,7 @@ UNUSED_COLUMNS = set(CSV_COLUMNS) - set(
 def model_fn(input_dim,
              labels_dim,
              hidden_units=[100, 70, 50, 20],
-             learning_rate=0.1):
+             learning_rate=0.001):
   """Create a Keras Sequential model with layers."""
   model = models.Sequential()
 
@@ -75,8 +75,7 @@ def model_fn(input_dim,
 
 def compile_model(model, learning_rate):
   model.compile(loss='categorical_crossentropy',
-                optimizer=keras.optimizers.SGD(lr=learning_rate),
-		#optimizer='adam',
+                optimizer=keras.optimizers.RMSprop(lr=learning_rate),
                 metrics=['accuracy'])
   return model
 

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -24,10 +24,8 @@ from keras.backend import relu, softmax
 
 #Python2/3 compatibility imports
 #   urlparse renamed urllib.parse
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
+from six.moves.urllib import parse as urlparse
+
 #   range
 from builtins import range
 

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -76,6 +76,7 @@ def model_fn(input_dim,
 def compile_model(model, learning_rate):
   model.compile(loss='categorical_crossentropy',
                 optimizer=keras.optimizers.RMSprop(lr=learning_rate),
+                #optimizer='adam',
                 metrics=['accuracy'])
   return model
 
@@ -128,7 +129,7 @@ def to_numeric_features(features,feature_cols=None):
 
   return features
 
-def generator_input(input_file, chunk_size):
+def generator_input(input_file, chunk_size,batch_size=64):
   """Generator function to produce features and labels
      needed by keras fit_generator.
   """
@@ -150,5 +151,6 @@ def generator_input(input_file, chunk_size):
         if feature_cols is None:
             feature_cols=input_data.columns
 
-        for index in xrange(input_data.shape[0]):
-            yield (input_data.iloc[[index]], label.iloc[[index]])
+        idx_len=input_data.shape[0]
+        for index in xrange(0,idx_len,batch_size):
+            yield (input_data.iloc[index:min(idx_len,index+batch_size)], label.iloc[index:min(idx_len,index+batch_size)])

--- a/census/keras/trainer/task.py
+++ b/census/keras/trainer/task.py
@@ -20,9 +20,10 @@ import glob
 import json
 import os
 
-import keras
+import trainer.model as model
+
+from keras.callbacks import TensorBoard, Callback, ModelCheckpoint
 from keras.models import load_model
-import model
 from tensorflow.python.lib.io import file_io
 
 INPUT_SIZE = 55
@@ -34,7 +35,7 @@ CHUNK_SIZE = 5000
 FILE_PATH = 'checkpoint.{epoch:02d}.hdf5'
 CENSUS_MODEL = 'census.hdf5'
 
-class ContinuousEval(keras.callbacks.Callback):
+class ContinuousEval(Callback):
   """Continuous eval callback to evaluate the checkpoint once
      every so many epochs.
   """
@@ -67,12 +68,12 @@ class ContinuousEval(keras.callbacks.Callback):
         loss, acc = census_model.evaluate_generator(
             model.generator_input(self.eval_files, chunk_size=CHUNK_SIZE),
             steps=self.steps)
-        print '\nEvaluation epoch[{}] metrics[{:.2f}, {:.2f}] {}'.format(
-            epoch, loss, acc, census_model.metrics_names)
+        print('\nEvaluation epoch[{}] metrics[{:.2f}, {:.2f}] {}'.format(
+            epoch, loss, acc, census_model.metrics_names))
         if self.job_dir.startswith("gs://"):
           copy_file_to_gcs(self.job_dir, checkpoints[-1])
       else:
-        print '\nEvaluation epoch[{}] (no checkpoints found)'.format(epoch)
+        print('\nEvaluation epoch[{}] (no checkpoints found)'.format(epoch))
 
 def dispatch(train_files,
              eval_files,
@@ -103,7 +104,7 @@ def dispatch(train_files,
     checkpoint_path = os.path.join(job_dir, checkpoint_path)
 
   # Model checkpoint callback
-  checkpoint = keras.callbacks.ModelCheckpoint(
+  checkpoint = ModelCheckpoint(
       checkpoint_path,
       monitor='val_loss',
       verbose=1,
@@ -117,7 +118,7 @@ def dispatch(train_files,
                               job_dir)
 
   # Tensorboard logs callback
-  tblog = keras.callbacks.TensorBoard(
+  tblog = TensorBoard(
       log_dir=os.path.join(job_dir, 'logs'),
       histogram_freq=0,
       write_graph=True,


### PR DESCRIPTION
Fix to enable the input generator to iterate over multiple file chunks and return to the file begging when reaching the end.
Also updated the feature extractor `to_numeric_features()` to return a consistent dataframe schema: the categorical classes are 'one hot' encoded based on the available values in the processed chunk, hence the returned column list may vary from a chunk to another (if new values are found or old are missing).

Added a mini-batch functionality to the generator_input (previous version returning one sample at a time). Training on generated mini-batches considerably* improves the performances. (I do not know how to reliably measure this on Google Cloud - this version seems to consume a 5th of the ML units and a 20th of the time, compared to the previous one, for the same processed volume). 

Finally, changed the model defaults to better fit the problem (and show some learning with the default example):
- softmax for the final activation
- RMSprop for the optimizer (along with the default learning rate) 
