### PR TITLE
readme updates to reflect 1.4 changes

### DIFF
--- a/census/README.md
+++ b/census/README.md
@@ -206,7 +206,7 @@ Run the distributed training code on cloud using `gcloud`.
 export SCALE_TIER=STANDARD_1
 export JOB_NAME=census
 export GCS_JOB_DIR=gs://<my-bucket>/path/to/my/models/$JOB_NAME
-export TRAIN_STEPS=1000
+export TRAIN_STEPS=5000
 ```
 
 ```
@@ -283,9 +283,9 @@ gsutil ls -r $GCS_JOB_DIR/export
 ```
 
 
- * Estimator Based: You should see a directory named `$GCS_JOB_DIR/export/Servo/<timestamp>`.
+ * Estimator Based: You should see a directory named `$GCS_JOB_DIR/export/census/<timestamp>`.
  ```
- export MODEL_BINARIES=$GCS_JOB_DIR/export/Servo/<timestamp>
+ export MODEL_BINARIES=$GCS_JOB_DIR/export/census/<timestamp>
  ```
 
  * Low Level Based: You should see a directory named `$GCS_JOB_DIR/export/JSON/`


### PR DESCRIPTION
Addresses the tf 1.4-related export path changes for the estimator example.  Also figured we might as well run the cmle training for more steps than locally.
Note: I did *not* check to see if the following re: the low level example had also changed.  It may need to be updated too.

 * Low Level Based: You should see a directory named `$GCS_JOB_DIR/export/JSON/`
   for `JSON`. See other formats `CSV` and `TFRECORD`.

