### PR TITLE
Update README.md

### DIFF
--- a/census/README.md
+++ b/census/README.md
@@ -306,7 +306,8 @@ gcloud ml-engine versions create v1 --model census --origin $MODEL_BINARIES --ru
 TensorFlow ships with a CLI that allows you to inspect the signature of exported binary files. To do this run:
 
 ```
-saved_model_cli show --dir $MODEL_BINARIES --tag serve --signature_def predict
+SIGNATURE_DEF_KEY=`saved_model_cli show --dir $MODEL_BINARIES --tag serve | grep "SignatureDef key:" | awk 'BEGIN{FS="\""}{print $2}' | head -1`
+saved_model_cli show --dir $MODEL_BINARIES --tag serve --signature_def $SIGNATURE_DEF_KEY
 ```
 
 ### Run Online Predictions


### PR DESCRIPTION
@amygdala Made changes to saved_model_cli argument so that signature_def_key is not hard coded. This is because canned vs custom produce different signature defs. This works with Cloud ML Engine because it essentially routes "predict" to default signature def aka signature_default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/140)
<!-- Reviewable:end -->
