### PR TITLE
A 'key' is required in the input for predictions

### DIFF
--- a/census/customestimator/README.md
+++ b/census/customestimator/README.md
@@ -1,0 +1,10 @@
+We use a custom estimator to construct a census model. The difference between 
+this model and the other two (tensorflow-core and canned estimator) is that
+a numeric 'key' is required in the input. The key will be passed through from
+the input to output. It is useful for the scenario of CMLE batch prediction where
+the output predictions are out of order. 
+
+
+* In the CSV input, specify a number in the first column in the input.
+* In the Example Proto input, specify a number in the numeric feature called 'key' in the input.
+* In the JSON input, specify a number in the input JSON object with the key of 'key'.

--- a/census/customestimator/trainer/model.py
+++ b/census/customestimator/trainer/model.py
@@ -157,7 +157,6 @@ def generate_model_fn(embedding_size=8,
     ]
 
     if mode == Modes.PREDICT:
-      # Convert predicted_indices back into strings
       key_tensor = features.pop(KEY)
 
     inputs = tf.feature_column.input_layer(features, transformed_columns)


### PR DESCRIPTION
The numeric key will act as a pass through field from inputs to output. This would be useful for Cloud ML engine batch prediction where the output predictions are not in the same order of inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/158)
<!-- Reviewable:end -->
