### PR TITLE
cloudml-template - updating the default params

### DIFF
--- a/cloudml-template/README.md
+++ b/cloudml-template/README.md
@@ -39,7 +39,6 @@ The examples show how the template is adapted given a dataset. The datasets are 
 
 |File Name| Purpose| Do You Need to Change?
 |:---|:---|:---
-
 |[metadata.py](template/trainer/metadata.py)|Defines: 1) task type, 2) input data header, 3) numeric and categorical feature names, 4) target feature name (and labels, for a classification task), and 5) unused feature names. | **Yes**, as you will need to specify the metadata of your dataset. **This might be the only module to change!**
 |[input.py](template/trainer/input.py)| Includes: 1) data input functions to read data from csv and tfrecords files, 2) parsing functions to convert csv and tf.example to tensors, 3) function to implement your features custom  processing and creation functionality, and 4) prediction functions (for serving the model) that accepts CSV, JSON, and tf.example instances. | **Maybe**, if you want to implement any custom pre-processing and feature creation during reading data.
 |[featurizer.py](template/trainer/featurizer.py)| Creates: 1) tensorflow feature_column(s) based on the dataset metadata (and other extended feature columns, e.g. bucketisation, crossing, embedding, etc.), and 2) deep and wide feature column lists. | **Maybe**, if you want to change your feature_column(s) and/or change how deep and wide columns are defined (see next section). 

--- a/cloudml-template/examples/babyweight-custom/trainer/task.py
+++ b/cloudml-template/examples/babyweight-custom/trainer/task.py
@@ -93,7 +93,7 @@ def initialise_hyper_params(args_parser):
         If both --train-size and --num-epochs are specified,
         --train-steps will be: (train-size/train-batch-size) * num-epochs.\
         """,
-        default=10,
+        default=None,
         type=int,
     )
     ###########################################
@@ -286,7 +286,6 @@ def run_experiment(run_config):
         eval_input_fn,
         steps=HYPER_PARAMS.eval_steps,
         exporters=[exporter],
-        name='estimator-eval',
         throttle_secs=HYPER_PARAMS.eval_every_secs,
     )
 
@@ -345,13 +344,13 @@ def main():
     # If job_dir_reuse is False then remove the job_dir if it exists
     print("Resume training:", HYPER_PARAMS.reuse_job_dir)
     if not HYPER_PARAMS.reuse_job_dir:
-        if tf.gfile.Exists(HYPER_PARAMS.job_dir):
-            tf.gfile.DeleteRecursively(HYPER_PARAMS.job_dir)
-            print("Deleted job_dir {} to avoid re-use".format(HYPER_PARAMS.job_dir))
+        if tf.gfile.Exists(model_dir):
+            tf.gfile.DeleteRecursively(model_dir)
+            print("Deleted job_dir {} to avoid re-use".format(model_dir))
         else:
             print("No job_dir available to delete")
     else:
-        print("Reusing job_dir {} if it exists".format(HYPER_PARAMS.job_dir))
+        print("Reusing job_dir {} if it exists".format(model_dir))
 
     run_config = tf.estimator.RunConfig(
         tf_random_seed=19830610,

--- a/cloudml-template/examples/census-classification/trainer/task.py
+++ b/cloudml-template/examples/census-classification/trainer/task.py
@@ -93,7 +93,7 @@ def initialise_hyper_params(args_parser):
         If both --train-size and --num-epochs are specified,
         --train-steps will be: (train-size/train-batch-size) * num-epochs.\
         """,
-        default=10,
+        default=100,
         type=int,
     )
     ###########################################
@@ -275,7 +275,6 @@ def run_experiment(run_config):
         eval_input_fn,
         steps=HYPER_PARAMS.eval_steps,
         exporters=[exporter],
-        name='estimator-eval',
         throttle_secs=HYPER_PARAMS.eval_every_secs,
     )
 
@@ -334,13 +333,13 @@ def main():
     # If job_dir_reuse is False then remove the job_dir if it exists
     print("Resume training:", HYPER_PARAMS.reuse_job_dir)
     if not HYPER_PARAMS.reuse_job_dir:
-        if tf.gfile.Exists(HYPER_PARAMS.job_dir):
-            tf.gfile.DeleteRecursively(HYPER_PARAMS.job_dir)
-            print("Deleted job_dir {} to avoid re-use".format(HYPER_PARAMS.job_dir))
+        if tf.gfile.Exists(model_dir):
+            tf.gfile.DeleteRecursively(model_dir)
+            print("Deleted job_dir {} to avoid re-use".format(model_dir))
         else:
             print("No job_dir available to delete")
     else:
-        print("Reusing job_dir {} if it exists".format(HYPER_PARAMS.job_dir))
+        print("Reusing job_dir {} if it exists".format(model_dir))
 
     run_config = tf.estimator.RunConfig(
         tf_random_seed=19830610,

--- a/cloudml-template/examples/german-custom/trainer/task.py
+++ b/cloudml-template/examples/german-custom/trainer/task.py
@@ -93,7 +93,7 @@ def initialise_hyper_params(args_parser):
         If both --train-size and --num-epochs are specified,
         --train-steps will be: (train-size/train-batch-size) * num-epochs.\
         """,
-        default=100,
+        default=None,
         type=int,
     )
     ###########################################
@@ -286,7 +286,6 @@ def run_experiment(run_config):
         eval_input_fn,
         steps=HYPER_PARAMS.eval_steps,
         exporters=[exporter],
-        name='estimator-eval',
         throttle_secs=HYPER_PARAMS.eval_every_secs,
     )
 
@@ -345,9 +344,9 @@ def main():
     # If job_dir_reuse is False then remove the job_dir if it exists
     print("Resume training:", HYPER_PARAMS.reuse_job_dir)
     if not HYPER_PARAMS.reuse_job_dir:
-        if tf.gfile.Exists(HYPER_PARAMS.job_dir):
-            tf.gfile.DeleteRecursively(HYPER_PARAMS.job_dir)
-            print("Deleted job_dir {} to avoid re-use".format(HYPER_PARAMS.job_dir))
+        if tf.gfile.Exists(model_dir):
+            tf.gfile.DeleteRecursively(model_dir)
+            print("Deleted job_dir {} to avoid re-use".format(model_dir))
         else:
             print("No job_dir available to delete")
     else:

--- a/cloudml-template/examples/housing-regression/trainer/task.py
+++ b/cloudml-template/examples/housing-regression/trainer/task.py
@@ -93,7 +93,7 @@ def initialise_hyper_params(args_parser):
         If both --train-size and --num-epochs are specified,
         --train-steps will be: (train-size/train-batch-size) * num-epochs.\
         """,
-        default=10,
+        default=None,
         type=int,
     )
     ###########################################
@@ -274,7 +274,6 @@ def run_experiment(run_config):
         eval_input_fn,
         steps=HYPER_PARAMS.eval_steps,
         exporters=[exporter],
-        name='estimator-eval',
         throttle_secs=HYPER_PARAMS.eval_every_secs,
     )
 
@@ -333,13 +332,13 @@ def main():
     # If job_dir_reuse is False then remove the job_dir if it exists
     print("Resume training:", HYPER_PARAMS.reuse_job_dir)
     if not HYPER_PARAMS.reuse_job_dir:
-        if tf.gfile.Exists(HYPER_PARAMS.job_dir):
-            tf.gfile.DeleteRecursively(HYPER_PARAMS.job_dir)
-            print("Deleted job_dir {} to avoid re-use".format(HYPER_PARAMS.job_dir))
+        if tf.gfile.Exists(model_dir):
+            tf.gfile.DeleteRecursively(model_dir)
+            print("Deleted job_dir {} to avoid re-use".format(model_dir))
         else:
             print("No job_dir available to delete")
     else:
-        print("Reusing job_dir {} if it exists".format(HYPER_PARAMS.job_dir))
+        print("Reusing job_dir {} if it exists".format(model_dir))
 
     run_config = tf.estimator.RunConfig(
         tf_random_seed=19830610,

--- a/cloudml-template/scripts/cloudml-submit-train-job.sh
+++ b/cloudml-template/scripts/cloudml-submit-train-job.sh
@@ -28,7 +28,7 @@ gcloud ml-engine jobs submit training ${JOB_NAME} \
         -- \
         --train-files=${TRAIN_FILES} \
         --eval-files=${EVAL_FILES} \
-		--train-steps=10000
+	--train-steps=10000
 
 
 # notes:

--- a/cloudml-template/scripts/cloudml-submit-train-job.sh
+++ b/cloudml-template/scripts/cloudml-submit-train-job.sh
@@ -10,7 +10,7 @@ MODEL_NAME="your_model_name" # change to your model name
 
 PACKAGE_PATH=trainer # this can be a gcs location to a zipped and uploaded package
 TRAIN_FILES=gs://${BUCKET}/path/to/data/train-data-*.csv
-VALID_FILES=gs://${BUCKET}/path/to/data/valid-data-*.csv
+EVAL_FILES=gs://${BUCKET}/path/to/data/eval-data-*.csv
 MODEL_DIR=gs://${BUCKET}/path/to/models/${MODEL_NAME}
 
 CURRENT_DATE=`date +%Y%m%d_%H%M%S`
@@ -27,15 +27,8 @@ gcloud ml-engine jobs submit training ${JOB_NAME} \
         --config=config.yaml \
         -- \
         --train-files=${TRAIN_FILES} \
-		--train-steps=10000 \
-        --num-epochs=10 \
-        --train-batch-size=200 \
-        --eval-files=${VALID_FILES} \
-        --eval-batch-size=200 \
-        --learning-rate=0.01 \
-        --hidden-units="64,32,10" \
-        --layer-sizes-scale-factor=0.5 \
-        --num-layers=3
+        --eval-files=${EVAL_FILES} \
+		--train-steps=10000
 
 
 # notes:

--- a/cloudml-template/template/trainer/task.py
+++ b/cloudml-template/template/trainer/task.py
@@ -93,7 +93,7 @@ def initialise_hyper_params(args_parser):
         If both --train-size and --num-epochs are specified,
         --train-steps will be: (train-size/train-batch-size) * num-epochs.\
         """,
-        default=10,
+        default=None,
         type=int,
     )
     ###########################################
@@ -287,7 +287,6 @@ def run_experiment(run_config):
         eval_input_fn,
         steps=HYPER_PARAMS.eval_steps,
         exporters=[exporter],
-        name='estimator-eval',
         throttle_secs=HYPER_PARAMS.eval_every_secs,
     )
 
@@ -346,13 +345,13 @@ def main():
     # If job_dir_reuse is False then remove the job_dir if it exists
     print("Resume training:", HYPER_PARAMS.reuse_job_dir)
     if not HYPER_PARAMS.reuse_job_dir:
-        if tf.gfile.Exists(HYPER_PARAMS.job_dir):
-            tf.gfile.DeleteRecursively(HYPER_PARAMS.job_dir)
-            print("Deleted job_dir {} to avoid re-use".format(HYPER_PARAMS.job_dir))
+        if tf.gfile.Exists(model_dir):
+            tf.gfile.DeleteRecursively(model_dir)
+            print("Deleted job_dir {} to avoid re-use".format(model_dir))
         else:
             print("No job_dir available to delete")
     else:
-        print("Reusing job_dir {} if it exists".format(HYPER_PARAMS.job_dir))
+        print("Reusing job_dir {} if it exists".format(model_dir))
 
     run_config = tf.estimator.RunConfig(
         tf_random_seed=19830610,


### PR DESCRIPTION
@puneith - I have made the following (minor) updates to the cloudml-template template & examples:

- Updating the --num-epoch default value to None, since it's use is not relevant unless the --train-size and the --train-batch-size parameters are specified, otherwise the --train-steps is used.

- Simplified the example script to submit a training job to CMLE, including only the necessary arguments

Note that the same exact changes were applied to the template, and the 4 examples.

These changes managed to resolve this issue #203 