### PR TITLE
removed Tensorflow version 1.2.0 requirement from Keras tutorial

### DIFF
--- a/census/keras/requirements.txt
+++ b/census/keras/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==1.2.0
+tensorflow
 Keras>=2.0.4,<3.0
 h5py>=2.7.0,<3.0
 pandas>=0.18.0,<1.0


### PR DESCRIPTION
The current Keras tutorial needs a newer version of Tensorflow to run successfully. This edit eliminates the version 1.2.0 requirement from requirements.txt.

This fix will resolve [Issue 210](https://github.com/GoogleCloudPlatform/cloudml-samples/issues/210).