### PR TITLE
Added project to DirectRunner pipeline options on Reddit TFT

### DIFF
--- a/reddit_tft/preprocess.py
+++ b/reddit_tft/preprocess.py
@@ -226,10 +226,13 @@ def main(argv=None):
                 os.path.dirname(__file__),
                 'setup.py')),
     }
-    pipeline_options = beam.pipeline.PipelineOptions(flags=[], **options)
   else:
     pipeline_name = 'DirectRunner'
-    pipeline_options = None
+    options = {
+      'project': args.project_id
+    }
+  
+  pipeline_options = beam.pipeline.PipelineOptions(flags=[], **options)
 
   temp_dir = os.path.join(args.output_dir, 'tmp')
   with beam.Pipeline(pipeline_name, options=pipeline_options) as p:


### PR DESCRIPTION
It seams like the latest google-cloud-dataflow (now 2.4.0) do not loads the default project for bigquery

The pipeline only parse the command line options if passed as `argv` argument ([docs](https://beam.apache.org/documentation/sdks/pydoc/2.4.0/apache_beam.pipeline.html#apache_beam.pipeline.Pipeline)), so doing what the error message suggests, add `--project [PROJECT_ID]` as a command line option, does not work

I can think of two solutions to this problem:  
1. Pass the unkown command line options to the `argv` argument of the pipeline
1. Build a `PipelineOptions` object for the Direct Runner, not only the Dataflow Runner

I used the second one to avoid having two redundant arguments (`--project_id` and `--project`)