### PR TITLE
changing sofmax to sigmoid

### DIFF
--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -20,7 +20,7 @@ import pandas as pd
 from keras import backend as K
 from keras import layers, models
 from keras.utils import np_utils
-from keras.backend import relu, softmax
+from keras.backend import relu
 
 #Python2/3 compatibility imports
 from six.moves.urllib import parse as urlparse
@@ -70,7 +70,7 @@ def model_fn(input_dim,
     input_dim = units
 
   # Add a dense final layer with sigmoid function
-  model.add(layers.Dense(labels_dim, activation="sigmoid"))
+  model.add(layers.Dense(labels_dim, activation='sigmoid'))
   compile_model(model, learning_rate)
   return model
 

--- a/census/keras/trainer/model.py
+++ b/census/keras/trainer/model.py
@@ -70,7 +70,7 @@ def model_fn(input_dim,
     input_dim = units
 
   # Add a dense final layer with sigmoid function
-  model.add(layers.Dense(labels_dim, activation=softmax))
+  model.add(layers.Dense(labels_dim, activation="sigmoid"))
   compile_model(model, learning_rate)
   return model
 


### PR DESCRIPTION
Changing the ```softmax``` activation to `sigmoid` activation at Line 73. Because if `labels_dim` is 1 then having `softmax` activation may have bad performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/241)
<!-- Reviewable:end -->
