### PR TITLE
Update Apache Beam requirements.txt

### DIFF
--- a/flowers/requirements.txt
+++ b/flowers/requirements.txt
@@ -1,3 +1,3 @@
-apache-beam[gcp]==0.6.0
+apache-beam[gcp]==2.6.0
 pillow==4.0.0
 tensorflow==1.4.1


### PR DESCRIPTION
Tutorial fails in this section:
https://cloud.google.com/ml-engine/docs/tensorflow/flowers-tutorial#evaluation_data_preprocessing
Apache beam 0.6.0 fails in [this](https://github.com/apache/beam/blob/release-0.6.0/sdks/python/apache_beam/runners/dataflow/internal/dependency.py#L506) step

Need a new version of apache beam.
Unable to run example, due to newer version of pip >9.0.3 --download flags is deprecated.
Reported issues:
https://github.com/GoogleCloudPlatform/cloudml-samples/issues/205
https://github.com/GoogleCloudPlatform/cloudml-samples/issues/196

Tested with new apache beam version and worked fine.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/246)
<!-- Reviewable:end -->
