### PR TITLE
Update preprocess.py to handle NameError

### DIFF
--- a/movielens/preprocess.py
+++ b/movielens/preprocess.py
@@ -322,6 +322,7 @@ class BuildExampleFn(beam.DoFn):
 @beam.ptransform_fn
 def _Shuffle(pcoll):  # pylint: disable=invalid-name
   """Shuffles a PCollection."""
+  import random
   return (pcoll
           | 'PairWithRand' >> beam.Map(lambda x: (random.random(), x))
           | 'GroupByRand' >> beam.GroupByKey()


### PR DESCRIPTION
Adding random import into method. Imports, functions and other variables defined in the global context of your main file of your Dataflow pipeline are, by default, not available in the worker execution environment, and such references will cause a NameError.

Please see https://cloud.google.com/dataflow/faq#how-do-i-handle-nameerrors for additional documentation on configuring your worker execution environment.

Reported here: Issue #250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/254)
<!-- Reviewable:end -->
