### PR TITLE
Swap out broken Tensorflow docs link

### DIFF
--- a/reddit_tft/README.md
+++ b/reddit_tft/README.md
@@ -31,19 +31,19 @@ This sample consists of two parts:
 
 Data pre-processing step involves reading data from Google Cloud BigQuery
 and converting it to
-[TFRecords](https://www.tensorflow.org/api_guides/python/python_io)
+[TFRecord](https://www.tensorflow.org/guide/datasets#consuming_tfrecord_data)
 format.
 
 ### Model Training
 
-Model training step involves taking the pre-processed TFRecords data and
+Model training step involves taking the pre-processed TFRecord data and
 training a linear classifier using Stochastic Dual Coordinate Ascent (SDCA)
 optimizer, or a deep neural network classifier.
 
 ## Data Format
 
 Above dataset is available in BigQuery and need to be transformed to
-TFRecords format for the sample code to work. Make sure to run the data through
+TFRecord format for the sample code to work. Make sure to run the data through
 the pre-processing step before you proceed to training.
 
 ## Pre-Processing Step


### PR DESCRIPTION
Also, @lamberta told me `TFRecord` is preferable to `TFRecords`.

(I'm making this fix on https://cloud.google.com/ml-engine/docs/tensorflow/samples so I figured I'd mirror it here.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/266)
<!-- Reviewable:end -->
