### PR TITLE
Using fixed version for torch in MNIST custom container sample

### DIFF
--- a/pytorch/containers/quickstart/mnist/Dockerfile
+++ b/pytorch/containers/quickstart/mnist/Dockerfile
@@ -17,7 +17,7 @@ FROM python:2.7.15-jessie
 WORKDIR /root
 
 # Installs pytorch and torchvision.
-RUN pip install torch torchvision
+RUN pip install torch==1.0.0 torchvision==0.2.1
 
 # Installs cloudml-hypertune for hyperparameter tuning.
 # It’s not needed if you don’t want to do hyperparameter tuning.

--- a/pytorch/containers/quickstart/mnist/Dockerfile-gpu
+++ b/pytorch/containers/quickstart/mnist/Dockerfile-gpu
@@ -31,7 +31,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 WORKDIR /root
 
 # Installs pytorch and torchvision.
-RUN pip install torch torchvision
+RUN pip install torch==1.0.0 torchvision==0.2.1
 
 # Installs cloudml-hypertune for hyperparameter tuning.
 # It’s not needed if you don’t want to do hyperparameter tuning.


### PR DESCRIPTION
There is an issue with latest torch version: https://github.com/pytorch/pytorch/issues/16775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/364)
<!-- Reviewable:end -->
