### PR TITLE
This change improve the input_pipeline performance.

### DIFF
--- a/cloudml-template/template/trainer/input.py
+++ b/cloudml-template/template/trainer/input.py
@@ -32,17 +32,18 @@ import task
 
 
 def parse_csv(csv_row, is_serving=False):
-    """Takes the string input tensor (csv) and returns a dict of rank-2 tensors.
+    """Takes a batch of csv rows and returns a dict of rank-2 tensors.
 
-    Takes a rank-1 tensor and converts it into rank-2 tensor, with respect to its data type
-    (inferred from the metadata)
+    Takes a rank-2 tensor and converts it into rank-2 tensor, with respect to
+    its data type (inferred from the metadata)
 
     Args:
-        csv_row: rank-2 tensor of type string (csv)
-        is_serving: boolean to indicate whether this function is called during serving or training
-        since the serving csv_row input is different than the training input (i.e., no target column)
+        csv_row: rank-2 tensor of type string (csv rows)
+        is_serving: boolean to indicate whether this function is called during
+        serving or training since the serving csv_row input is different than
+        the training input (i.e., no target column)
     Returns:
-        rank-2 tensor of the correct data type
+        rank-2 tensors' dictionary of the correct data type
     """
 
     if is_serving:
@@ -52,16 +53,17 @@ def parse_csv(csv_row, is_serving=False):
         column_names = metadata.HEADER
         defaults = metadata.HEADER_DEFAULTS
 
-    columns = tf.decode_csv(tf.expand_dims(csv_row, -1), record_defaults=defaults)
+    defaults = [[default] for default in defaults]
+    columns = tf.decode_csv(csv_row, record_defaults=defaults)
     features = dict(zip(column_names, columns))
 
     return features
 
 
 def parse_tf_example(example_proto, is_serving=False):
-    """Takes the string input tensor (example proto) and returns a dict of rank-2 tensors.
+    """Takes a batch of string input tensors (example proto) and returns a dict of rank-2 tensors.
 
-    Takes a rank-1 tensor and converts it into rank-2 tensor, with respect to its data type
+    Takes a rank-2 tensor and converts it into a dictionary of rank-2 tensor, with respect to its data type
     (inferred from the  metadata)
 
     Args:
@@ -69,7 +71,7 @@ def parse_tf_example(example_proto, is_serving=False):
         is_serving: boolean to indicate whether this function is called during serving or training
         since the serving csv_row input is different than the training input (i.e., no target column)
     Returns:
-        rank-2 tensor of the correct data type
+        rank-2 tensors' dictionary of the correct data type
     """
 
     feature_spec = {}
@@ -213,13 +215,22 @@ def generate_input_fn(file_names_pattern,
         file_names = tf.matching_files(file_names_pattern)
 
         if file_encoding == 'csv':
-            dataset = data.TextLineDataset(filenames=file_names)
-            dataset = dataset.skip(skip_header_lines)
-            dataset = dataset.map(lambda csv_row: parse_csv(csv_row))
+            # Parallely processes num_threads files at the time.
+            # Also, since the batch function is called before the map function
+            # we use a block lenght of 1 to output one batch from every input
+            # file before moving to the next file
+            dataset = (data.Dataset.from_tensor_slices(file_names)
+              .interleave(lambda x:
+                data.TextLineDataset(x)
+                .skip(skip_header_lines)
+                .batch(batch_size)
+                .map(parse_csv, num_parallel_calls=num_threads),
+                  cycle_length=num_threads, block_length=1))
 
         else:
             dataset = data.TFRecordDataset(filenames=file_names)
-            dataset = dataset.map(lambda tf_example: parse_tf_example(tf_example),
+            dataset = dataset = dataset.batch(batch_size)
+            dataset = dataset.map(lambda tf_examples: parse_tf_example(tf_examples),
                                   num_parallel_calls=num_threads)
 
         dataset = dataset.map(lambda features: get_features_target_tuple(features),
@@ -230,7 +241,6 @@ def generate_input_fn(file_names_pattern,
         if shuffle:
             dataset = dataset.shuffle(buffer_size)
 
-        dataset = dataset.batch(batch_size)
         dataset = dataset.prefetch(buffer_size)
         dataset = dataset.repeat(num_epochs)
 


### PR DESCRIPTION
This is achieved by calling batching the raw input first and then
calling the map function for each batch. This follows the considerations
described [here](https://www.tensorflow.org/guide/performance/datasets#map_and_batch).

In a related project this change boosted throughput on a CSV dataset by
a factor of 2.

Finally, now the pipeline support skipping the header for every CSV
file. Before it was failed if the CSV dataset consisted of multiple
files each with a header.

P.S. after speaking with @gogasca this will be the first of several improvements. I wonder if I should open one/several issues to track this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/365)
<!-- Reviewable:end -->
