### PR TITLE
Update preprocess.py

### DIFF
--- a/census/keras/preprocess.py
+++ b/census/keras/preprocess.py
@@ -23,7 +23,7 @@ from trainer import model
 
 if __name__=='__main__':
   gen = model.generator_input(['adult.data.csv'], chunk_size=5000)
-  sample = gen.next()
+  sample = gen.__next__()
 
   input_sample = {}
 


### PR DESCRIPTION
gen.next() doesn't exist anymore, we will have to change it to gen.__next__() for 3.0 python version and above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/371)
<!-- Reviewable:end -->
