### PR TITLE
Specify training dependency versions (fixes #419)

### DIFF
--- a/notebooks/scikit-learn/custom-pipeline.ipynb
+++ b/notebooks/scikit-learn/custom-pipeline.ipynb
@@ -981,7 +981,8 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud beta ai-platform versions create $VERSION_NAME --model $MODEL_NAME \\\n",
+        "# --quiet automatically installs the beta component if it isn't already installed \n",
+        "! gcloud --quiet beta ai-platform versions create $VERSION_NAME --model $MODEL_NAME \\\n",
         "  --origin gs://$BUCKET_NAME/custom_pipeline_tutorial/model/ \\\n",
         "  --runtime-version 1.13 \\\n",
         "  --python-version 3.5 \\\n",

--- a/notebooks/scikit-learn/custom-pipeline.ipynb
+++ b/notebooks/scikit-learn/custom-pipeline.ipynb
@@ -981,8 +981,6 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud components install beta\n",
-        "\n",
         "! gcloud beta ai-platform versions create $VERSION_NAME --model $MODEL_NAME \\\n",
         "  --origin gs://$BUCKET_NAME/custom_pipeline_tutorial/model/ \\\n",
         "  --runtime-version 1.13 \\\n",

--- a/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
+++ b/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
@@ -461,7 +461,7 @@
       },
       "cell_type": "code",
       "source": [
-        "! pip install numpy scikit-learn"
+        "! pip install numpy>=1.16.0 scikit-learn==0.20.2"
       ],
       "execution_count": 0,
       "outputs": []

--- a/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
+++ b/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
@@ -825,8 +825,6 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud components install beta\n",
-        "\n",
         "! gcloud beta ai-platform versions create $VERSION_NAME \\\n",
         "  --model $MODEL_NAME \\\n",
         "  --runtime-version 1.13 \\\n",

--- a/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
+++ b/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb
@@ -825,7 +825,8 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud beta ai-platform versions create $VERSION_NAME \\\n",
+        "# --quiet automatically installs the beta component if it isn't already installed \n",
+        "! gcloud --quiet beta ai-platform versions create $VERSION_NAME \\\n",
         "  --model $MODEL_NAME \\\n",
         "  --runtime-version 1.13 \\\n",
         "  --python-version 3.5 \\\n",

--- a/notebooks/tensorflow/custom-prediction-routine-keras.ipynb
+++ b/notebooks/tensorflow/custom-prediction-routine-keras.ipynb
@@ -841,7 +841,8 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud beta ai-platform versions create $VERSION_NAME \\\n",
+        "# --quiet automatically installs the beta component if it isn't already installed \n",
+        "! gcloud --quiet beta ai-platform versions create $VERSION_NAME \\\n",
         "  --model $MODEL_NAME \\\n",
         "  --runtime-version 1.13 \\\n",
         "  --python-version 3.5 \\\n",

--- a/notebooks/tensorflow/custom-prediction-routine-keras.ipynb
+++ b/notebooks/tensorflow/custom-prediction-routine-keras.ipynb
@@ -841,8 +841,6 @@
       },
       "cell_type": "code",
       "source": [
-        "! gcloud components install beta\n",
-        "\n",
         "! gcloud beta ai-platform versions create $VERSION_NAME \\\n",
         "  --model $MODEL_NAME \\\n",
         "  --runtime-version 1.13 \\\n",


### PR DESCRIPTION
This addresses #419 by making sure the version of scikit-learn (and thus joblib) used during training matches the version of scikit-learn (and thus joblib) used during prediction in AI Platform runtime version 1.13.

[Run the update notebook in Colab.](https://colab.research.google.com/github/GoogleCloudPlatform/cloudml-samples/blob/alecglassford-patch-5/notebooks/scikit-learn/custom-prediction-routine-scikit-learn.ipynb)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/421)
<!-- Reviewable:end -->
