### PR TITLE
python2 -> python3 for census/tensorflowcore tutorial

### DIFF
--- a/census/tensorflowcore/trainer/model.py
+++ b/census/tensorflowcore/trainer/model.py
@@ -45,7 +45,7 @@ LABELS = [' <=50K', ' >50K']
 LABEL_COLUMN = 'income_bracket'
 
 UNUSED_COLUMNS = set(CSV_COLUMNS) - set(
-    zip(*CATEGORICAL_COLS)[0] + CONTINUOUS_COLS + (LABEL_COLUMN,))
+    list(zip(*CATEGORICAL_COLS))[0] + CONTINUOUS_COLS + (LABEL_COLUMN,))
 
 TRAIN, EVAL, PREDICT = 'TRAIN', 'EVAL', 'PREDICT'
 CSV, EXAMPLE, JSON = 'CSV', 'EXAMPLE', 'JSON'
@@ -99,7 +99,7 @@ def model_fn(mode,
   # Concatenate the (now all dense) features.
   # We need to sort the tensors so that they end up in the same order for
   # prediction, evaluation, and training
-  sorted_feature_tensors = zip(*sorted(features.iteritems()))[1]
+  sorted_feature_tensors = list(zip(*sorted(features.items())))[1]
   inputs = tf.concat(sorted_feature_tensors, 1)
 
   # Build the DNN

--- a/census/tensorflowcore/trainer/task.py
+++ b/census/tensorflowcore/trainer/task.py
@@ -84,7 +84,7 @@ class EvaluationRunHook(tf.train.SessionRunHook):
       self._gs = tf.train.get_or_create_global_step()
 
       self._final_ops_dict = value_dict
-      self._eval_ops = update_dict.values()
+      self._eval_ops = list(update_dict.values())
 
     # MonitoredTrainingSession runs hooks in background threads
     # and it doesn't wait for the thread from the last session.run()


### PR DESCRIPTION
Doing census tutorial at https://cloud.google.com/ml-engine/docs/tensorflow/getting-started-training-prediction

Tried to run in python3 runtime but the code was not compatible, I fixed it and now run correctly in both python2 and python3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/424)
<!-- Reviewable:end -->
