### PR TITLE
Add instruction to README.md of molecules

### DIFF
--- a/molecules/README.md
+++ b/molecules/README.md
@@ -48,6 +48,14 @@ You can use the `requirements.txt` to install the dependencies.
 pip install -U -r requirements.txt
 ```
 
+### Cloud SDK Setup (Optional)
+
+If you have never created application default credentials (ADC), you can create it by `gcloud` command. Following steps are required to `./run-cloud`. 
+
+```bash
+gcloud auth application-default login
+```
+
 ## Quickstart
 We'll start by running the end-to-end script locally. To run simply run the [`run-local`](run-local) comand:
 ```bash


### PR DESCRIPTION
In initial setup step, add creating ADC step since ‘./run-cloud’ command requires it.
See also : https://stackoverflow.com/questions/44401088/using-training-tfrecords-that-are-stored-on-google-cloud

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/428)
<!-- Reviewable:end -->
