### PR TITLE
Added cleanup step to remove unsupported characters in labels

### DIFF
--- a/notebooks/scikit-learn/20_newsgroups_automl.ipynb
+++ b/notebooks/scikit-learn/20_newsgroups_automl.ipynb
@@ -1,411 +1,296 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Copyright 2019 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Prepare data for *Google Cloud AutoML Natural Language* from scikit-learn"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook demonstrates how to prepare text data available in scikit-learn (or other libraries), so that it can be used in [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl).\n",
-    "\n",
-    "The script reads the data into a pandas dataframe, and then makes some minor transformations to ensure that it is compatible with the AutoML Natural Language input specification. Finally, the CSV is saved into a CSV file, which can be downloaded from the notebook server."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2tr1DfOiz9cb"
-   },
-   "source": [
-    "This notebook downloads the [20 newsgroups dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html) using scikit-learn. This dataset contains about 18000 posts from 20 newsgroups, and is useful for text classification. More details on the dataset can be found [here](http://qwone.com/~jason/20Newsgroups/)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Objectives"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "There are 3 goals for this notebook:\n",
-    "1. Introduce scikit-learn datasets\n",
-    "2. Explore pandas dataframe text manipulation\n",
-    "3. Import data into AutoML Natural language for text classification"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## What's next?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "After downloading the CSV at the end of this notebook, import the data into [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl) to explore classifying text."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "K65WZ6bMz9cc"
-   },
-   "source": [
-    "## Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "OZDimb-5z9cd"
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import csv\n",
-    "\n",
-    "from sklearn.datasets import fetch_20newsgroups"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "zYxeG10oz9cg"
-   },
-   "source": [
-    "## Fetch data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 202
+      "name": "20_newsgroups_automl.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
     },
-    "colab_type": "code",
-    "id": "mV7b2hHfz9ch",
-    "outputId": "ae65520d-7b7e-4834-c449-e2c1c01a99e2"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>text</th>\n",
-       "      <th>categories</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>From: Mamatha Devineni Ratnam &lt;mr47+@andrew.cm...</td>\n",
-       "      <td>rec.sport.hockey</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>From: mblawson@midway.ecn.uoknor.edu (Matthew ...</td>\n",
-       "      <td>comp.sys.ibm.pc.hardware</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>From: hilmi-er@dsv.su.se (Hilmi Eren)\\nSubject...</td>\n",
-       "      <td>talk.politics.mideast</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>From: guyd@austin.ibm.com (Guy Dawson)\\nSubjec...</td>\n",
-       "      <td>comp.sys.ibm.pc.hardware</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>From: Alexander Samuel McDiarmid &lt;am2o+@andrew...</td>\n",
-       "      <td>comp.sys.mac.hardware</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                text                categories\n",
-       "0  From: Mamatha Devineni Ratnam <mr47+@andrew.cm...          rec.sport.hockey\n",
-       "1  From: mblawson@midway.ecn.uoknor.edu (Matthew ...  comp.sys.ibm.pc.hardware\n",
-       "2  From: hilmi-er@dsv.su.se (Hilmi Eren)\\nSubject...     talk.politics.mideast\n",
-       "3  From: guyd@austin.ibm.com (Guy Dawson)\\nSubjec...  comp.sys.ibm.pc.hardware\n",
-       "4  From: Alexander Samuel McDiarmid <am2o+@andrew...     comp.sys.mac.hardware"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "newsgroups = fetch_20newsgroups(subset='all')\n",
-    "\n",
-    "df = pd.DataFrame(newsgroups.data, columns=['text'])\n",
-    "df['categories'] = [newsgroups.target_names[index] for index in newsgroups.target]\n",
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "RMJqpjZwz9cl"
-   },
-   "source": [
-    "## Clean data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 202
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     },
-    "colab_type": "code",
-    "id": "K6yd6XSLz9cl",
-    "outputId": "0d0f7c32-df26-4d72-c13e-674cfc88c06c"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>text</th>\n",
-       "      <th>categories</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>8107</th>\n",
-       "      <td>From: robinson@cogsci.Berkeley.EDU (Michael Ro...</td>\n",
-       "      <td>rec.motorcycles</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17762</th>\n",
-       "      <td>From: carl@lvsun.com (Carl Shapiro) Subject: R...</td>\n",
-       "      <td>sci.crypt</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8282</th>\n",
-       "      <td>From: kerr@ux1.cso.uiuc.edu (Stan Kerr) Subjec...</td>\n",
-       "      <td>comp.windows.x</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17911</th>\n",
-       "      <td>From: henry@zoo.toronto.edu (Henry Spencer) Su...</td>\n",
-       "      <td>sci.space</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13403</th>\n",
-       "      <td>From: depolo@eniac.seas.upenn.edu (Jeff Depolo...</td>\n",
-       "      <td>sci.electronics</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                    text       categories\n",
-       "8107   From: robinson@cogsci.Berkeley.EDU (Michael Ro...  rec.motorcycles\n",
-       "17762  From: carl@lvsun.com (Carl Shapiro) Subject: R...        sci.crypt\n",
-       "8282   From: kerr@ux1.cso.uiuc.edu (Stan Kerr) Subjec...   comp.windows.x\n",
-       "17911  From: henry@zoo.toronto.edu (Henry Spencer) Su...        sci.space\n",
-       "13403  From: depolo@eniac.seas.upenn.edu (Jeff Depolo...  sci.electronics"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.5.3"
     }
-   ],
-   "source": [
-    "# Convert multiple whitespace characters into a space\n",
-    "df['text'] = df['text'].str.replace('\\s+',' ')\n",
-    "\n",
-    "# Trim leading and tailing whitespace\n",
-    "df['text'] = df['text'].str.strip()\n",
-    "\n",
-    "# Truncate all fields to the maximum field length of 128kB\n",
-    "df['text'] = df['text'].str.slice(0,131072)\n",
-    "\n",
-    "# Remove any rows with empty fields\n",
-    "df = df.replace('', np.NaN).dropna()\n",
-    "\n",
-    "# Drop duplicates\n",
-    "df = df.drop_duplicates(subset='text')\n",
-    "\n",
-    "# Limit rows to maximum of 100,000\n",
-    "df = df.sample(min(100000, len(df)))\n",
-    "\n",
-    "df.head()"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "exFdr6wVz9co"
-   },
-   "source": [
-    "## Export to CSV"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "pYUzEq-oz9cp"
-   },
-   "outputs": [],
-   "source": [
-    "csv_str = df.to_csv(index=False, header=False)\n",
-    "\n",
-    "with open(\"20-newsgroups-dataset.csv\", \"w\") as text_file:\n",
-    "    print(csv_str, file=text_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1kJX0DKHz9cr"
-   },
-   "source": [
-    "You're all set! Download `20-newsgroups-dataset.csv` and import it into [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl).\n",
-    "\n",
-    "If you are using [Google Colab](https://colab.research.google.com), you will find the file in the left navbar:\n",
-    "\n",
-    "\n",
-    "*   From the menu, select **View > Table of Contents**\n",
-    "*   Navigate to the **Files** tab\n",
-    "*   Select `..` and find the file in `/content` directory\n",
-    "*   Download the CSV with the context menu\n",
-    "\n",
-    "\n"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "20_newsgroups_automl.ipynb",
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "C7aGlpdRrgfu",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Copyright 2019 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xxG_Nzjqrgfy",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Prepare data for *Google Cloud AutoML Natural Language* from scikit-learn"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SENX9Cxcrgfz",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Overview"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MnBTX49Trgfz",
+        "colab_type": "text"
+      },
+      "source": [
+        "This notebook demonstrates how to prepare text data available in scikit-learn (or other libraries), so that it can be used in [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl).\n",
+        "\n",
+        "The script reads the data into a pandas dataframe, and then makes some minor transformations to ensure that it is compatible with the AutoML Natural Language input specification. Finally, the CSV is saved into a CSV file, which can be downloaded from the notebook server."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aO6uxkAargf0",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "2tr1DfOiz9cb"
+      },
+      "source": [
+        "This notebook downloads the [20 newsgroups dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html) using scikit-learn. This dataset contains about 18000 posts from 20 newsgroups, and is useful for text classification. More details on the dataset can be found [here](http://qwone.com/~jason/20Newsgroups/)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3YvJahe6rgf1",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Objectives"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yYDsrG-5rgf2",
+        "colab_type": "text"
+      },
+      "source": [
+        "There are 3 goals for this notebook:\n",
+        "1. Introduce scikit-learn datasets\n",
+        "2. Explore pandas dataframe text manipulation\n",
+        "3. Import data into AutoML Natural language for text classification"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fBN89gpLrgf3",
+        "colab_type": "text"
+      },
+      "source": [
+        "## What's next?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hFUQL3Rirgf3",
+        "colab_type": "text"
+      },
+      "source": [
+        "After downloading the CSV at the end of this notebook, import the data into [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl) to explore classifying text."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "K65WZ6bMz9cc"
+      },
+      "source": [
+        "## Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "OZDimb-5z9cd",
+        "colab": {}
+      },
+      "source": [
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import csv\n",
+        "\n",
+        "from sklearn.datasets import fetch_20newsgroups"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "zYxeG10oz9cg"
+      },
+      "source": [
+        "## Fetch data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "mV7b2hHfz9ch",
+        "colab": {}
+      },
+      "source": [
+        "newsgroups = fetch_20newsgroups(subset='all')\n",
+        "\n",
+        "df = pd.DataFrame(newsgroups.data, columns=['text'])\n",
+        "df['categories'] = [newsgroups.target_names[index] for index in newsgroups.target]\n",
+        "df.head()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "RMJqpjZwz9cl"
+      },
+      "source": [
+        "## Clean data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "K6yd6XSLz9cl",
+        "colab": {}
+      },
+      "source": [
+        "# Convert multiple whitespace characters into a space\n",
+        "df['text'] = df['text'].str.replace('\\s+',' ')\n",
+        "\n",
+        "# Change newsgroup titles to use underscores rather than periods\n",
+        "df['categories'] = df['categories'].str.replace('.','_')\n",
+        "\n",
+        "# Trim leading and tailing whitespace\n",
+        "df['text'] = df['text'].str.strip()\n",
+        "\n",
+        "# Truncate all fields to the maximum field length of 128kB\n",
+        "df['text'] = df['text'].str.slice(0,131072)\n",
+        "\n",
+        "# Remove any rows with empty fields\n",
+        "df = df.replace('', np.NaN).dropna()\n",
+        "\n",
+        "# Drop duplicates\n",
+        "df = df.drop_duplicates(subset='text')\n",
+        "\n",
+        "# Limit rows to maximum of 100,000\n",
+        "df = df.sample(min(100000, len(df)))\n",
+        "\n",
+        "df.head()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "exFdr6wVz9co"
+      },
+      "source": [
+        "## Export to CSV"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "pYUzEq-oz9cp",
+        "colab": {}
+      },
+      "source": [
+        "csv_str = df.to_csv(index=False, header=False)\n",
+        "\n",
+        "with open(\"20-newsgroups-dataset.csv\", \"w\") as text_file:\n",
+        "    print(csv_str, file=text_file)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "1kJX0DKHz9cr"
+      },
+      "source": [
+        "You're all set! Download `20-newsgroups-dataset.csv` and import it into [Google Cloud AutoML Natural Language](https://cloud.google.com/natural-language/automl).\n",
+        "\n",
+        "If you are using [Google Colab](https://colab.research.google.com), you will find the file in the left navbar:\n",
+        "\n",
+        "\n",
+        "*   From the menu, select **View > Table of Contents**\n",
+        "*   Navigate to the **Files** tab\n",
+        "*   Select `..` and find the file in `/content` directory\n",
+        "*   Download the CSV with the context menu\n",
+        "\n",
+        "\n"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
AutoML Natural Language previously allowed labels such as `comp.graphics` but would change them to become valid, e.g. `comp_graphics`. Now, AutoML NL throws an error.

The change in the notebook is to add this step:
```
# Change newsgroup titles to use underscores rather than periods
df['categories'] = df['categories'].str.replace('.','_')
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/450)
<!-- Reviewable:end -->
