### PR TITLE
Update census/tf-keras save_keras_model output

### DIFF
--- a/census/tf-keras/trainer/task.py
+++ b/census/tf-keras/trainer/task.py
@@ -118,10 +118,9 @@ def train_and_evaluate(args):
       verbose=1,
       callbacks=[lr_decay_cb, tensorboard_cb])
 
-  export_path = tf.contrib.saved_model.save_keras_model(
-      keras_model, os.path.join(args.job_dir, 'keras_export'))
-  export_path = export_path.decode('utf-8')
-  print('Model exported to: ', export_path)
+  export_path = os.path.join(args.job_dir, 'keras_export')
+  tf.contrib.saved_model.save_keras_model(keras_model, export_path)
+  print('Model exported to: {}'.format(export_path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Otherwise I have error when running locally:

```
I0827 10:10:30.505312 4518344128 builder_impl.py:421] SavedModel written to: local-training-output/keras_export/saved_model.pb
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/fuyangl/cloudml-samples/census/tf-keras/trainer/task.py", line 130, in <module>
    train_and_evaluate(args)
  File "/Users/fuyangl/cloudml-samples/census/tf-keras/trainer/task.py", line 123, in train_and_evaluate
    export_path = export_path.decode('utf-8')
AttributeError: 'NoneType' object has no attribute 'decode'
```