### PR TITLE
Use gs://cloud-samples-data/ai-platform/ directory for docs

### DIFF
--- a/census/tf-keras/trainer/util.py
+++ b/census/tf-keras/trainer/util.py
@@ -29,7 +29,7 @@ import tensorflow as tf
 DATA_DIR = os.path.join(tempfile.gettempdir(), 'census_data')
 
 # Download options.
-DATA_URL = ('https://storage.googleapis.com/cloud-samples-data/ml-engine/census'
+DATA_URL = ('https://storage.googleapis.com/cloud-samples-data/ai-platform/census'
             '/data')
 TRAINING_FILE = 'adult.data.csv'
 EVAL_FILE = 'adult.test.csv'

--- a/notebooks/scikit-learn/custom-pipeline.ipynb
+++ b/notebooks/scikit-learn/custom-pipeline.ipynb
@@ -123,7 +123,7 @@
         "marital status, occupation, and whether they make more than $50,000 a year.\n",
         "\n",
         "The data used in this tutorial is available in a public Cloud Storage bucket:\n",
-        "[`gs://cloud-samples-data/ml-engine/sklearn/census_data/`](https://console.cloud.google.com/storage/browser/cloud-samples-data/ml-engine/sklearn/census_data/)"
+        "[`gs://cloud-samples-data/ai-platform/sklearn/census_data/`](https://console.cloud.google.com/storage/browser/cloud-samples-data/ai-platform/sklearn/census_data/)"
       ]
     },
     {
@@ -796,7 +796,7 @@
         "  --scale-tier BASIC \\\n",
         "  --stream-logs \\\n",
         "  -- \\\n",
-        "  --gcs_data_path gs://cloud-samples-data/ml-engine/census/data/adult.data.csv \\\n",
+        "  --gcs_data_path gs://cloud-samples-data/ai-platform/census/data/adult.data.csv \\\n",
         "  --gcs_model_path gs://$BUCKET_NAME/custom_pipeline_tutorial/model/model.joblib"
       ],
       "execution_count": 0,

--- a/notebooks/tensorflow/getting-started-keras.ipynb
+++ b/notebooks/tensorflow/getting-started-keras.ipynb
@@ -67,7 +67,7 @@
       "source": [
         "# Getting started: Training and prediction with Keras in AI Platform\n",
         "\n",
-        "<img src=\"https://storage.googleapis.com/cloud-samples-data/ml-engine/census/keras-tensorflow-cmle.png\" alt=\"Keras, TensorFlow, and AI Platform logos\" width=\"300px\">\n",
+        "<img src=\"https://storage.googleapis.com/cloud-samples-data/ai-platform/census/keras-tensorflow-cmle.png\" alt=\"Keras, TensorFlow, and AI Platform logos\" width=\"300px\">\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td>\n",
@@ -2850,7 +2850,7 @@
         "DATA_DIR = os.path.join(tempfile.gettempdir(), 'census_data')\n",
         "\n",
         "# Download options.\n",
-        "DATA_URL = 'https://storage.googleapis.com/cloud-samples-data/ml-engine' \\\n",
+        "DATA_URL = 'https://storage.googleapis.com/cloud-samples-data/ai-platform' \\\n",
         "           '/census/data'\n",
         "TRAINING_FILE = 'adult.data.csv'\n",
         "EVAL_FILE = 'adult.test.csv'\n",

--- a/sklearn/notebooks/census_training/train.py
+++ b/sklearn/notebooks/census_training/train.py
@@ -12,7 +12,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelBinarizer
 
 
-# TODO: REPLACE 'YOUR_BUCKET_NAME' with your GCS Bucket name. 
+# TODO: REPLACE 'YOUR_BUCKET_NAME' with your GCS Bucket name.
 BUCKET_NAME = 'YOUR_BUCKET_NAME'
 # [END setup]
 
@@ -26,7 +26,7 @@ BUCKET_NAME = 'YOUR_BUCKET_NAME'
 bucket = storage.Client().bucket('cloud-samples-data')
 
 # Path to the data inside the public bucket
-blob = bucket.blob('ml-engine/sklearn/census_data/adult.data')
+blob = bucket.blob('ai-platform/sklearn/census_data/adult.data')
 # Download the data
 blob.download_to_filename('adult.data')
 # [END download-data]
@@ -96,15 +96,15 @@ for i, col in enumerate(COLUMNS[:-1]):
     if col in CATEGORICAL_COLUMNS:
         # Create a scores array to get the individual categorical column.
         # Example:
-        #  data = [39, 'State-gov', 77516, 'Bachelors', 13, 'Never-married', 'Adm-clerical', 
+        #  data = [39, 'State-gov', 77516, 'Bachelors', 13, 'Never-married', 'Adm-clerical',
         #         'Not-in-family', 'White', 'Male', 2174, 0, 40, 'United-States']
         #  scores = [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         #
-        # Returns: [['State-gov']]      
+        # Returns: [['State-gov']]
         # Build the scores array.
-        scores = [0] * len(COLUMNS[:-1]) 
+        scores = [0] * len(COLUMNS[:-1])
         # This column is the categorical column we want to extract.
-        scores[i] = 1  
+        scores[i] = 1
         skb = SelectKBest(k=1)
         skb.scores_ = scores
         # Convert the categorical column to a numerical value

--- a/xgboost/iris_training.py
+++ b/xgboost/iris_training.py
@@ -16,7 +16,7 @@ BUCKET_NAME = '<YOUR_BUCKET_NAME>'
 # [START download-data]
 iris_data_filename = 'iris_data.csv'
 iris_target_filename = 'iris_target.csv'
-data_dir = 'gs://cloud-samples-data/ml-engine/iris'
+data_dir = 'gs://cloud-samples-data/ai-platform/iris'
 
 # gsutil outputs everything to stderr so we need to divert it to stdout.
 subprocess.check_call(['gsutil', 'cp', os.path.join(data_dir,

--- a/xgboost/notebooks/census_training/train.py
+++ b/xgboost/notebooks/census_training/train.py
@@ -24,7 +24,7 @@ census_data_filename = 'adult.data.csv'
 bucket = storage.Client().bucket('cloud-samples-data')
 
 # Path to the data inside the public bucket
-data_dir = 'ml-engine/census/data/'
+data_dir = 'ai-platform/census/data/'
 
 # Download the data
 blob = bucket.blob(''.join([data_dir, census_data_filename]))
@@ -79,7 +79,7 @@ train_labels = (raw_training_data['income-level'] == ' >50K')
 
 # [START categorical-feature-conversion]
 # Since the census data set has categorical features, we need to convert
-# them to numerical values. 
+# them to numerical values.
 # convert data in categorical columns to numerical values
 encoders = {col:LabelEncoder() for col in CATEGORICAL_COLUMNS}
 for col in CATEGORICAL_COLUMNS:


### PR DESCRIPTION
There's a new gs://cloud-samples-data/ai-platform/ directory with all the same contents as gs://cloud-samples-data/ml-engine/.

gs://cloud-samples-data/ml-engine/ is referenced in a lot of places in this repository, and I don't think it's necessary to change every instance (nor do I want to, at the risk of breaking something).

This PR just changes instances that are included/referenced directly in the AI Platform documentation, in order to improve branding with in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloudml-samples/454)
<!-- Reviewable:end -->
