### PR TITLE
chore: Exclude TensorFlow from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "packageRules": [
+    {
+      "excludePackageNames": [
+        "tensorflow"
+      ]
+    }
+  ]  
 }


### PR DESCRIPTION
TensorFlow 1.x to 2.x was a major upgrade. Automatic upgrades will break notebooks.